### PR TITLE
Use config file

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,16 @@
+# Specify the resolution
+dx=15km
+
+# Directory containing MPAS files
+datadir=/glade/campaign/mmm/wmr/fjudt/projects/dyamond_1/$dx
+
+# Associative array mapping resolution names to mesh IDs
+declare -A mesh_dict
+mesh_dict["480km"]=2562
+mesh_dict["240km"]=10242
+mesh_dict["120km"]=40962
+mesh_dict["60km"]=163842
+mesh_dict["30km"]=655362
+mesh_dict["15km"]=2621442
+mesh_dict["7.5km"]=10458762
+mesh_dict["3.75km"]=41943042

--- a/config.sh
+++ b/config.sh
@@ -4,6 +4,7 @@ dx=15km
 # Directory containing MPAS files
 datadir=/glade/campaign/mmm/wmr/fjudt/projects/dyamond_1/$dx
 
+# Modify the 'mesh_dict' associative array to map resolution names to the corresponding mesh IDs.
 # Associative array mapping resolution names to mesh IDs
 declare -A mesh_dict
 mesh_dict["480km"]=2562

--- a/convert_lonVertex.py
+++ b/convert_lonVertex.py
@@ -20,6 +20,7 @@ Dependencies:
 import shutil
 import numpy as np
 import netCDF4 as nc
+import os
 
 # Directory containing MPAS grid files
 datadir = "/glade/scratch/fjudt/mpas_meshes"
@@ -42,6 +43,8 @@ dx = "15km"
 # Source and destination file paths
 src_file = f"{datadir}/x1.{resolution_dir[dx]}.grid.nc"
 dst_file = f"{datadir}/x1.{resolution_dir[dx]}.grid.modified-lonVertex.nc"
+base, ext = os.path.splitext(src_file)
+dst_file = base + ".modified-lonVertex" + ext
 
 # Copy the source file to the destination
 shutil.copyfile(src_file, dst_file)

--- a/create_SCRIP-file.sh
+++ b/create_SCRIP-file.sh
@@ -5,35 +5,17 @@
 # This script converts MPAS grid files to SCRIP format using the 'scrip_from_mpas' command.
 
 # Instructions:
-# 1. Make sure the 'conda' command is available on your system.
-# 2. Activate the 'mpas-tools' Conda environment before dxning this script.
-# 3. Set the 'datadir' variable to the directory containing the MPAS mesh files.
-# 4. Modify the 'mesh_dict' associative array to map resolution names to the corresponding mesh IDs.
-# 5. Specify the desired resolution by setting the 'dx' variable to the desired resolution.
-# 6. Run this script to convert the MPAS grid file to SCRIP format.
+# 1. Install mpas_tools before running this script by running `conda install mpas_tools`.
+# 2. Run this script to convert the MPAS grid file to SCRIP format.
 
 # Load the 'conda' module
 module load conda
 
-# Activate the 'mpas-tools' environment (get it from https://github.com/MPAS-Dev/MPAS-Tools)
+# Activate conda environment with mpas_tools
 conda activate mpas-tools
 
-# Directory containing MPAS files
-datadir="/glade/campaign/mmm/wmr/fjudt/projects/dyamond_1/$dx"
-
-# Associative array mapping resolution names to mesh IDs
-declare -A mesh_dict
-mesh_dict["480km"]=2562
-mesh_dict["240km"]=10242
-mesh_dict["120km"]=40962
-mesh_dict["60km"]=163842
-mesh_dict["30km"]=655362
-mesh_dict["15km"]=2621442
-mesh_dict["7.5km"]=10458762
-mesh_dict["3.75km"]=41943042
-
-# Specify the desired resolution to convert
-dx="15km"
+# Define dx, datadir, and mesh_dict.
+. config.sh
 
 # Path to the grid file with modified lonVertex variable
 gridfile="/glade/scratch/fjudt/mpas_meshes/x1.${mesh_dict[$dx]}.grid.modified-lonVertex.nc"

--- a/create_connectivity-file.sh
+++ b/create_connectivity-file.sh
@@ -7,25 +7,12 @@
 # This script generates a grid connectivity file using the 'GenerateConnectivityFile' command.
 
 # Instructions:
-# 1. Modify the 'mesh_dict' associative array to map resolution names to the corresponding mesh IDs.
-# 2. Specify the desired resolution by setting the 'dx' variable to the desired resolution.
-# 3. Set the 'scripfile' variable to the path of the SCRIP file.
-# 4. Set the 'gridconnectivityfile' variable to the desired path for the grid connectivity file.
-# 5. Run this script to generate the grid connectivity file.
+# 1. Set the 'scripfile' variable to the path of the SCRIP file.
+# 2. Set the 'gridconnectivityfile' variable to the desired path for the grid connectivity file.
+# 3. Run this script to generate the grid connectivity file.
 
-# Associative array mapping resolution names to mesh IDs
-declare -A mesh_dict
-mesh_dict["480km"]=2562
-mesh_dict["240km"]=10242
-mesh_dict["120km"]=40962
-mesh_dict["60km"]=163842
-mesh_dict["30km"]=655362
-mesh_dict["15km"]=2621442
-mesh_dict["7.5km"]=10458762
-mesh_dict["3.75km"]=41943042
-
-# Specify the desired resolution for grid connectivity generation
-dx="15km"
+# Define dx, datadir, and mesh_dict.
+. config.sh
 
 # Path to the SCRIP file
 scripfile="/glade/scratch/fjudt/mpas_meshes/x1.${mesh_dict[$dx]}.grid.SCRIP.nc"


### PR DESCRIPTION
Put repeated definition of mesh_dict and dx in its own configuration file, config.sh.
Simplify instructions.

Use os.path.splitext to insert subtring between base filename and extension.